### PR TITLE
Prevent from using incompletely downloaded files

### DIFF
--- a/src/android/AssetBundle.java
+++ b/src/android/AssetBundle.java
@@ -115,6 +115,14 @@ class AssetBundle {
         ownAssetsByURLPath.put(asset.urlPath, asset);
     }
 
+    public Uri getDirectoryUri() {
+        return directoryUri;
+    }
+
+    public File getDirectory() {
+        return resourceApi.mapUriToFile(directoryUri);
+    }
+
     public Set<Asset> getOwnAssets() {
         return new HashSet<Asset>(ownAssetsByURLPath.values());
     }


### PR DESCRIPTION
This deals with the situation in which an incompletely downloaded file
is saved to disk and later treated like a fully downloaded one. This
can happen on slow, disconnecting internet connections.